### PR TITLE
CortexPalRegister.py: build URL from configured app_id; update README

### DIFF
--- a/CortexPalRegister.py
+++ b/CortexPalRegister.py
@@ -2,11 +2,10 @@ import requests
 import configparser
 import time
 
-url = "https://discord.com/api/v8/applications/697790419035226112/commands"
-
 config = configparser.ConfigParser()
 config.read('cortexpal.ini')
 
+url = "https://discord.com/api/v8/applications/{}/commands".format(config['discord']['app_id'])
 headers = {
     "Authorization": "Bot {}".format(config['discord']['token'])
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ file=(path and filename for the application log file)
 
 [discord]
 token=(the Discord bot token, from the developer portal)
+app_id=(the Discord application ID, from the developer portal)
 public_key=(the Discord application public key, from the developer portal)
 
 [database]


### PR DESCRIPTION
Solves `{"message": "You are not authorized to perform this action on this application", "code": 20012}` errors due to hard-coded application ID.